### PR TITLE
Trailing quote breaks PostDown

### DIFF
--- a/wgzero
+++ b/wgzero
@@ -175,7 +175,7 @@ SaveConfig = true
 PrivateKey = $(cat "$CONFIGFOLDER"/priv.key)
 ListenPort = $(GetConf port)
 PostUp = /usr/sbin/iptables -A FORWARD -i %i -j ACCEPT; /usr/sbin/iptables -A FORWARD -o %i -j ACCEPT; /usr/sbin/iptables -t nat -A POSTROUTING -o $(GetConf interface) -j MASQUERADE
-PostDown = /usr/sbin/iptables -D FORWARD -i %i -j ACCEPT; /usr/sbin/iptables -D FORWARD -o %i -j ACCEPT; /usr/sbin/iptables -t nat -D POSTROUTING -o $(GetConf interface) -j MASQUERADE"
+PostDown = /usr/sbin/iptables -D FORWARD -i %i -j ACCEPT; /usr/sbin/iptables -D FORWARD -o %i -j ACCEPT; /usr/sbin/iptables -t nat -D POSTROUTING -o $(GetConf interface) -j MASQUERADE
 
 EOF
 


### PR DESCRIPTION
`sudo wg-quick down wg0`
```
[#] wg showconf wg0
[#] ip link delete dev wg0
[#] /usr/sbin/iptables -D FORWARD -i wg0 -j ACCEPT; /usr/sbin/iptables -D FORWARD -o wg0 -j ACCEPT; /usr/sbin/iptables -t nat -D POSTROUTING -o ens3 -j MASQUERADE"
/usr/bin/wg-quick: eval: line 295: unexpected EOF while looking for matching `"'
```